### PR TITLE
fix bug in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Now we can get our code working by changing render to the following:
 ```javascript
 function render() {
   let container = document.getElementById('container');
-  container.textContent = store.getState.count;
+  container.textContent = store.getState().count;
 };
 
 store = createStore();
@@ -186,8 +186,6 @@ function createStore(reducer) {
     return state;
   };
 
-  dispatch({ type: '@@INIT' });
-
   return {
     dispatch, 
     getState
@@ -207,10 +205,11 @@ function changeCount(state = { count: 0 }, action) {
 
 function render() {
   let container = document.getElementById('container');
-  container.textContent = store.getState.count;
+  container.textContent = store.getState().count;
 };
 
-let store = createStore(changeCount) // createStore takes the changeCount reducer as an argument
+let store = createStore(changeCount); // createStore takes the changeCount reducer as an argument
+store.dispatch({ type: '@@INIT' });
 let button = document.getElementById('button');
 
 button.addEventListener('click', function() {


### PR DESCRIPTION
@Lukeghenco, @curiositypaths 

Resolves #10,#11 & #12.
Another student mentioned this in an issue on the learn-co-students repo as well, but `store.getState` is a function, so we need to call it to actually get the state out. There's another error in here as well. If we call the dispatch method from within createStore, we get an error because `store` is not defined yet (we're assigning the return value of `createStore` to `store` and so `store` won't be defined yet when we hit this line in the dispatch funtion:
`container.textContent = store.getState().count`

moving this initially dispatched action outside of createStore and right below the line where we define `store` fixes the problem.